### PR TITLE
Support top-level await - fixes #1

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -61,6 +61,18 @@ If we don't change the test file and we run the `tsd-check` command again, the t
 
 <img src="screenshot.png" width="1330">
 
+### Top-level `await`
+
+If your method returns a `Promise`, you can use top-level `await` to resolve the value instead of wrapping it in an `async` [IIFE](https://developer.mozilla.org/en-US/docs/Glossary/IIFE).
+
+```ts
+import {expectType} from 'tsd-check';
+import concat from '.';
+
+expectType<Promise<string>>(concat('foo', 'bar'));
+
+expectType<string>(await concat('foo', 'bar'));
+```
 
 
 ## Assertions

--- a/source/lib/compiler.ts
+++ b/source/lib/compiler.ts
@@ -2,6 +2,11 @@ import * as path from 'path';
 import {createProgram, getPreEmitDiagnostics, ScriptTarget, ModuleResolutionKind, flattenDiagnosticMessageText} from 'typescript';
 import {Diagnostic, Context} from './interfaces';
 
+// List of diagnostic codes that should be ignored
+const ignoredDiagnostics = new Set<number>([
+	1308 // Support top-level `await`
+]);
+
 const loadConfig = () => {
 	return {
 		moduleResolution: ModuleResolutionKind.NodeJs,
@@ -28,7 +33,7 @@ export const getDiagnostics = (context: Context): Diagnostic[] => {
 	const result: Diagnostic[] = [];
 
 	for (const diagnostic of diagnostics) {
-		if (!diagnostic.file) {
+		if (!diagnostic.file || ignoredDiagnostics.has(diagnostic.code)) {
 			continue;
 		}
 


### PR DESCRIPTION
This small fix allows you to use top-level await in your test files. We can simply ignore the error by checking the error code and filter it out of our diagnostics list.

The only downside is that VSCode still shows it as an error but running `tsd-check` works perfectly fine.

<img width="364" alt="screen shot 2018-09-05 at 20 00 03" src="https://user-images.githubusercontent.com/1913805/45111858-5a8fca00-b146-11e8-8d5e-b12ede00b699.png">

I don't think there's much we can do about that.

Is this good enough for you @sindresorhus?