### PR TITLE
fix: print error output

### DIFF
--- a/source/cli.ts
+++ b/source/cli.ts
@@ -31,7 +31,7 @@ const cli = meow(`
 			throw new Error(`Found ${diagnostics.length} issues.`);
 		}
 	} catch (e) {
-		console.error(e)
+		console.error(e);
 		process.exit(1);
 	}
 })();

--- a/source/cli.ts
+++ b/source/cli.ts
@@ -30,7 +30,8 @@ const cli = meow(`
 
 			throw new Error(`Found ${diagnostics.length} issues.`);
 		}
-	} catch {
+	} catch (e) {
+		console.error(e)
 		process.exit(1);
 	}
 })();

--- a/source/cli.ts
+++ b/source/cli.ts
@@ -30,8 +30,8 @@ const cli = meow(`
 
 			throw new Error(`Found ${diagnostics.length} issues.`);
 		}
-	} catch (e) {
-		console.error(e);
+	} catch (error) {
+		console.error(error);
 		process.exit(1);
 	}
 })();

--- a/source/cli.ts
+++ b/source/cli.ts
@@ -31,7 +31,7 @@ const cli = meow(`
 			throw new Error(`Found ${diagnostics.length} issues.`);
 		}
 	} catch (error) {
-		console.error(error);
+		console.error(error.message);
 		process.exit(1);
 	}
 })();

--- a/source/cli.ts
+++ b/source/cli.ts
@@ -26,9 +26,7 @@ const cli = meow(`
 		const diagnostics = await tsdCheck(options);
 
 		if (diagnostics.length > 0) {
-			console.log(formatter(diagnostics));
-
-			throw new Error(`Found ${diagnostics.length} issues.`);
+			throw new Error(formatter(diagnostics));
 		}
 	} catch (error) {
 		console.error(error.message);


### PR DESCRIPTION
I ran into the `The type definition index.test-d.ts does not exist. Create one and try again.` error due to a naming mistake, but didn't realise until I made this change to print the error output. 

Happy to adjust formatting if this manner of printing the entire error isn't desired.