### PR TITLE
 Use `types` property, correctly test `files` for types in project sub-dirs

### DIFF
--- a/source/lib/index.ts
+++ b/source/lib/index.ts
@@ -10,7 +10,7 @@ interface Options {
 }
 
 const findTypingsFile = async (pkg: any, options: Options) => {
-	const typings = pkg.typings || 'index.d.ts';
+	const typings = pkg.types || pkg.typings || 'index.d.ts';
 
 	const typingsExist = await pathExists(path.join(options.cwd, typings));
 

--- a/source/lib/rules/files-property.ts
+++ b/source/lib/rules/files-property.ts
@@ -11,9 +11,15 @@ import {getJSONPropertyPosition} from '../utils';
  */
 export default (context: Context): Diagnostic[] => {
 	const {pkg, typingsFile} = context;
-	const typingsFileName = path.basename(typingsFile);
 
-	if (!Array.isArray(pkg.files) || pkg.files.indexOf(typingsFileName) !== -1) {
+	if (!Array.isArray(pkg.files)) {
+		return [];
+	}
+
+	const normalizedTypingsFile = path.normalize(typingsFile);
+	const normalizedFiles = (pkg.files as string[]).map(path.normalize);
+
+	if (normalizedFiles.includes(normalizedTypingsFile)) {
 		return [];
 	}
 
@@ -22,7 +28,7 @@ export default (context: Context): Diagnostic[] => {
 	return [
 		{
 			fileName: 'package.json',
-			message: `TypeScript type definition \`${typingsFileName}\` is not part of the \`files\` list.`,
+			message: `TypeScript type definition \`${normalizedTypingsFile}\` is not part of the \`files\` list.`,
 			severity: 'error',
 			...getJSONPropertyPosition(content, 'files')
 		}

--- a/source/test/fixtures/test-in-subdir/package.json
+++ b/source/test/fixtures/test-in-subdir/package.json
@@ -1,0 +1,9 @@
+{
+	"name": "foo",
+	"main": "src/index.js",
+	"typings": "src/index.d.ts",
+	"files": [
+		"src/index.js",
+		"src/index.d.ts"
+	]
+}

--- a/source/test/fixtures/test-in-subdir/src/index.d.ts
+++ b/source/test/fixtures/test-in-subdir/src/index.d.ts
@@ -1,0 +1,6 @@
+declare const one: {
+	(foo: string, bar: string): string;
+	(foo: number, bar: number): number;
+};
+
+export default one;

--- a/source/test/fixtures/test-in-subdir/src/index.js
+++ b/source/test/fixtures/test-in-subdir/src/index.js
@@ -1,0 +1,3 @@
+module.exports.default = (foo, bar) => {
+	return foo + bar;
+};

--- a/source/test/fixtures/test-in-subdir/src/index.test-d.ts
+++ b/source/test/fixtures/test-in-subdir/src/index.test-d.ts
@@ -1,0 +1,5 @@
+import {expectType} from '../../../..';
+import one from '.';
+
+expectType<string>(one('foo', 'bar'));
+expectType<number>(one(1, 2));

--- a/source/test/fixtures/test-non-barrel-main-via-types/foo.d.ts
+++ b/source/test/fixtures/test-non-barrel-main-via-types/foo.d.ts
@@ -1,0 +1,6 @@
+declare const one: {
+	(foo: string, bar: string): string;
+	(foo: number, bar: number): number;
+};
+
+export default one;

--- a/source/test/fixtures/test-non-barrel-main-via-types/foo.js
+++ b/source/test/fixtures/test-non-barrel-main-via-types/foo.js
@@ -1,0 +1,3 @@
+module.exports.default = (foo, bar) => {
+	return foo + bar;
+};

--- a/source/test/fixtures/test-non-barrel-main-via-types/foo.test-d.ts
+++ b/source/test/fixtures/test-non-barrel-main-via-types/foo.test-d.ts
@@ -1,0 +1,5 @@
+import {expectType} from '../../..';
+import one from './foo';
+
+expectType<string>(one('foo', 'bar'));
+expectType<number>(one(1, 2));

--- a/source/test/fixtures/test-non-barrel-main-via-types/package.json
+++ b/source/test/fixtures/test-non-barrel-main-via-types/package.json
@@ -1,0 +1,9 @@
+{
+	"name": "foo",
+	"main": "foo.js",
+	"types": "foo.d.ts",
+	"files": [
+		"foo.js",
+		"foo.d.ts"
+	]
+}

--- a/source/test/fixtures/test-non-barrel-main/foo.d.ts
+++ b/source/test/fixtures/test-non-barrel-main/foo.d.ts
@@ -1,0 +1,6 @@
+declare const one: {
+	(foo: string, bar: string): string;
+	(foo: number, bar: number): number;
+};
+
+export default one;

--- a/source/test/fixtures/test-non-barrel-main/foo.js
+++ b/source/test/fixtures/test-non-barrel-main/foo.js
@@ -1,0 +1,3 @@
+module.exports.default = (foo, bar) => {
+	return foo + bar;
+};

--- a/source/test/fixtures/test-non-barrel-main/foo.test-d.ts
+++ b/source/test/fixtures/test-non-barrel-main/foo.test-d.ts
@@ -1,0 +1,5 @@
+import {expectType} from '../../..';
+import one from './foo';
+
+expectType<string>(one('foo', 'bar'));
+expectType<number>(one(1, 2));

--- a/source/test/fixtures/test-non-barrel-main/package.json
+++ b/source/test/fixtures/test-non-barrel-main/package.json
@@ -1,0 +1,9 @@
+{
+	"name": "foo",
+	"main": "foo.js",
+	"typings": "foo.d.ts",
+	"files": [
+		"foo.js",
+		"foo.d.ts"
+	]
+}

--- a/source/test/test.ts
+++ b/source/test/test.ts
@@ -49,6 +49,24 @@ test('return no diagnostics', async t => {
 	t.true(diagnostics.length === 0);
 });
 
+test('support non-barrel main', async t => {
+	const diagnostics = await m({cwd: path.join(__dirname, 'fixtures/test-non-barrel-main')});
+
+	t.true(diagnostics.length === 0);
+});
+
+test('support non-barrel main using `types` property', async t => {
+	const diagnostics = await m({cwd: path.join(__dirname, 'fixtures/test-non-barrel-main-via-types')});
+
+	t.true(diagnostics.length === 0);
+});
+
+test('support testing in sub-directories', async t => {
+	const diagnostics = await m({cwd: path.join(__dirname, 'fixtures/test-in-subdir')});
+
+	t.true(diagnostics.length === 0);
+});
+
 test('support top-level await', async t => {
 	const diagnostics = await m({cwd: path.join(__dirname, 'fixtures/top-level-await')});
 


### PR DESCRIPTION
This fixes following problems:

- allow types to be defined in `types` field instead of `typings`
- check for full (relative) path to types file when testing the `files` field, not only for the filename