### PR TITLE
Make it strict by default and add ability to configure `compilerOptions`

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,12 +42,13 @@
 		"eslint-formatter-pretty": "^1.3.0",
 		"meow": "^5.0.0",
 		"path-exists": "^3.0.0",
+		"pkg-conf": "^3.0.0",
 		"read-pkg-up": "^4.0.0",
 		"typescript": "^3.0.1",
 		"update-notifier": "^2.5.0"
 	},
 	"devDependencies": {
-		"@types/node": "^10.7.1",
+		"@types/node": "^11.10.4",
 		"@types/update-notifier": "^2.2.0",
 		"ava": "*",
 		"cpy-cli": "^2.0.0",

--- a/source/lib/compiler.ts
+++ b/source/lib/compiler.ts
@@ -7,17 +7,26 @@ import {
 	createProgram
 } from 'typescript';
 import {Diagnostic, Context} from './interfaces';
+import * as pkgConf from 'pkg-conf';
 
 // List of diagnostic codes that should be ignored
 const ignoredDiagnostics = new Set<number>([
 	1308 // Support top-level `await`
 ]);
 
-const loadConfig = (): CompilerOptions => {
+const loadConfig = (cwd: string): CompilerOptions => {
+	const config = pkgConf.sync('tsd-check', {
+		cwd,
+		defaults: {compilerOptions: {}}
+	});
+
 	return {
-		moduleResolution: ModuleResolutionKind.NodeJs,
-		skipLibCheck: true,
-		target: ScriptTarget.ES2015
+		...config.compilerOptions,
+		...{
+			moduleResolution: ModuleResolutionKind.NodeJs,
+			skipLibCheck: true,
+			target: ScriptTarget.ES2015
+		}
 	};
 };
 
@@ -28,7 +37,7 @@ const loadConfig = (): CompilerOptions => {
  * @returns List of diagnostics
  */
 export const getDiagnostics = (context: Context): Diagnostic[] => {
-	const compilerOptions = loadConfig();
+	const compilerOptions = loadConfig(context.cwd);
 
 	const fileName = path.join(context.cwd, context.testFile);
 

--- a/source/lib/compiler.ts
+++ b/source/lib/compiler.ts
@@ -4,7 +4,8 @@ import {
 	ModuleResolutionKind,
 	flattenDiagnosticMessageText,
 	CompilerOptions,
-	createProgram
+	createProgram,
+	JsxEmit
 } from 'typescript';
 import {Diagnostic, Context} from './interfaces';
 import * as pkgConf from 'pkg-conf';
@@ -20,6 +21,7 @@ const loadConfig = (cwd: string): CompilerOptions => {
 		defaults: {
 			compilerOptions: {
 				strict: true,
+				jsx: JsxEmit.React,
 				target: ScriptTarget.ES2017
 			}
 		}

--- a/source/lib/compiler.ts
+++ b/source/lib/compiler.ts
@@ -17,15 +17,19 @@ const ignoredDiagnostics = new Set<number>([
 const loadConfig = (cwd: string): CompilerOptions => {
 	const config = pkgConf.sync('tsd-check', {
 		cwd,
-		defaults: {compilerOptions: {}}
+		defaults: {
+			compilerOptions: {
+				strict: true,
+				target: ScriptTarget.ES2017
+			}
+		}
 	});
 
 	return {
 		...config.compilerOptions,
 		...{
 			moduleResolution: ModuleResolutionKind.NodeJs,
-			skipLibCheck: true,
-			target: ScriptTarget.ES2015
+			skipLibCheck: true
 		}
 	};
 };
@@ -45,14 +49,18 @@ export const getDiagnostics = (context: Context): Diagnostic[] => {
 
 	const program = createProgram([fileName], compilerOptions);
 
-	const diagnostics = program.getSemanticDiagnostics().concat(program.getSyntacticDiagnostics());
+	const diagnostics = program
+		.getSemanticDiagnostics()
+		.concat(program.getSyntacticDiagnostics());
 
 	for (const diagnostic of diagnostics) {
 		if (!diagnostic.file || ignoredDiagnostics.has(diagnostic.code)) {
 			continue;
 		}
 
-		const position = diagnostic.file.getLineAndCharacterOfPosition(diagnostic.start as number);
+		const position = diagnostic.file.getLineAndCharacterOfPosition(
+			diagnostic.start as number
+		);
 
 		result.push({
 			fileName: diagnostic.file.fileName,

--- a/source/lib/compiler.ts
+++ b/source/lib/compiler.ts
@@ -1,4 +1,5 @@
 import * as path from 'path';
+import * as pkgConf from 'pkg-conf';
 import {
 	ScriptTarget,
 	ModuleResolutionKind,
@@ -8,7 +9,6 @@ import {
 	JsxEmit
 } from 'typescript';
 import {Diagnostic, Context} from './interfaces';
-import * as pkgConf from 'pkg-conf';
 
 // List of diagnostic codes that should be ignored
 const ignoredDiagnostics = new Set<number>([

--- a/source/test/fixtures/failure-strict-null-checks/index.d.ts
+++ b/source/test/fixtures/failure-strict-null-checks/index.d.ts
@@ -1,0 +1,1 @@
+export default function (foo: number): number | null;

--- a/source/test/fixtures/failure-strict-null-checks/index.js
+++ b/source/test/fixtures/failure-strict-null-checks/index.js
@@ -1,0 +1,3 @@
+module.exports.default = foo => {
+	return foo > 0 ? foo : null;
+};

--- a/source/test/fixtures/failure-strict-null-checks/index.test-d.ts
+++ b/source/test/fixtures/failure-strict-null-checks/index.test-d.ts
@@ -1,0 +1,4 @@
+import {expectType} from '../../..';
+import aboveZero from '.';
+
+expectType<number>(aboveZero(1));

--- a/source/test/fixtures/failure-strict-null-checks/package.json
+++ b/source/test/fixtures/failure-strict-null-checks/package.json
@@ -1,0 +1,8 @@
+{
+	"name": "foo",
+	"tsd-check": {
+		"compilerOptions": {
+			"strict": true
+		}
+	}
+}

--- a/source/test/fixtures/failure-strict-null-checks/package.json
+++ b/source/test/fixtures/failure-strict-null-checks/package.json
@@ -1,8 +1,3 @@
 {
-	"name": "foo",
-	"tsd-check": {
-		"compilerOptions": {
-			"strict": true
-		}
-	}
+	"name": "foo"
 }

--- a/source/test/fixtures/non-strict-check-with-config/index.d.ts
+++ b/source/test/fixtures/non-strict-check-with-config/index.d.ts
@@ -1,0 +1,1 @@
+export default function (foo: number): number | null;

--- a/source/test/fixtures/non-strict-check-with-config/index.js
+++ b/source/test/fixtures/non-strict-check-with-config/index.js
@@ -1,0 +1,3 @@
+module.exports.default = foo => {
+	return foo > 0 ? foo : null;
+};

--- a/source/test/fixtures/non-strict-check-with-config/index.test-d.ts
+++ b/source/test/fixtures/non-strict-check-with-config/index.test-d.ts
@@ -1,0 +1,4 @@
+import {expectType} from '../../..';
+import aboveZero from '.';
+
+expectType<number>(aboveZero(1));

--- a/source/test/fixtures/non-strict-check-with-config/package.json
+++ b/source/test/fixtures/non-strict-check-with-config/package.json
@@ -1,0 +1,8 @@
+{
+	"name": "foo",
+	"tsd-check": {
+		"compilerOptions": {
+			"strict": false
+		}
+	}
+}

--- a/source/test/test.ts
+++ b/source/test/test.ts
@@ -43,7 +43,7 @@ test('fail if typings file is not part of `files` list', async t => {
 	]);
 });
 
-test('fail if tests don\'t pass in strict mode with strict mode enabled in settings', async t => {
+test('fail if tests don\'t pass in strict mode', async t => {
 	const diagnostics = await m({
 		cwd: path.join(__dirname, 'fixtures/failure-strict-null-checks')
 	});
@@ -58,6 +58,14 @@ test('fail if tests don\'t pass in strict mode with strict mode enabled in setti
 	t.is(severity, 'error');
 	t.is(line, 4);
 	t.is(column, 19);
+});
+
+test('pass in loose mode when strict mode is disabled in settings', async t => {
+	const diagnostics = await m({
+		cwd: path.join(__dirname, 'fixtures/non-strict-check-with-config')
+	});
+
+	t.true(diagnostics.length === 0);
 });
 
 test('return no diagnostics', async t => {

--- a/source/test/test.ts
+++ b/source/test/test.ts
@@ -43,6 +43,23 @@ test('fail if typings file is not part of `files` list', async t => {
 	]);
 });
 
+test('fail if tests don\'t pass in strict mode with strict mode enabled in settings', async t => {
+	const diagnostics = await m({
+		cwd: path.join(__dirname, 'fixtures/failure-strict-null-checks')
+	});
+
+	const {fileName, message, severity, line, column} = diagnostics[0];
+	t.true(/failure-strict-null-checks\/index.test-d.ts$/.test(fileName));
+	t.is(
+		message,
+		`Argument of type 'number | null' is not assignable to parameter of type 'number'.
+  Type \'null\' is not assignable to type 'number'.`
+	);
+	t.is(severity, 'error');
+	t.is(line, 4);
+	t.is(column, 19);
+});
+
 test('return no diagnostics', async t => {
 	const diagnostics = await m({cwd: path.join(__dirname, 'fixtures/success')});
 


### PR DESCRIPTION
This PR changes the compiler so that it will respect the config in `package.json`s  `tsd-check.compilerOptions` field and pass this config through to the TS compiler.