### PR TITLE
Fix `expectError` to work in included files

### DIFF
--- a/source/lib/interfaces.ts
+++ b/source/lib/interfaces.ts
@@ -19,6 +19,7 @@ export interface Diagnostic {
 }
 
 export interface Position {
+	fileName: string;
 	start: number;
 	end: number;
 }

--- a/source/test/fixtures/expect-error/values/included-file.ts
+++ b/source/test/fixtures/expect-error/values/included-file.ts
@@ -1,5 +1,4 @@
 import {expectError} from '../../../..';
-import './included-file';
 
-expectError<string>(1);
 expectError<string>('fo');
+expectError<string>(1);

--- a/source/test/test.ts
+++ b/source/test/test.ts
@@ -164,10 +164,17 @@ test('expectError should not ignore syntactical errors', async t => {
 test('expectError for values', async t => {
 	const diagnostics = await m({cwd: path.join(__dirname, 'fixtures/expect-error/values')});
 
-	t.true(diagnostics.length === 1);
+	t.true(diagnostics.length === 2);
 
+	t.regex(diagnostics[0].fileName, /included-file.ts$/);
 	t.true(diagnostics[0].column === 0);
-	t.true(diagnostics[0].line === 4);
+	t.true(diagnostics[0].line === 3);
 	t.true(diagnostics[0].message === 'Expected an error, but found none.');
 	t.true(diagnostics[0].severity === 'error');
+
+	t.regex(diagnostics[1].fileName, /index.test-d.ts$/);
+	t.true(diagnostics[1].column === 0);
+	t.true(diagnostics[1].line === 5);
+	t.true(diagnostics[1].message === 'Expected an error, but found none.');
+	t.true(diagnostics[1].severity === 'error');
 });


### PR DESCRIPTION
Currently, only the main entry file is considered as possible source of diagnostic errors for `expectError`. If an assertion is made in an imported module, `tsd-check` will show a false positive.

This PR fixes this by iterating over all `program` files and collecting all possible sources for `expectError` diagnostic messages.