### PR TITLE
Ignore more diagnostics with `expectError`

### DIFF
--- a/source/lib/compiler.ts
+++ b/source/lib/compiler.ts
@@ -69,6 +69,11 @@ const extractExpectErrorRanges = (sourceFile: SourceFile) => {
 	return expectedErrors;
 };
 
+const diagnosticCodesToIgnore = [
+	DiagnosticCode.ArgumentTypeIsNotAssignableToParameterType,
+	DiagnosticCode.PropertyDoesNotExistOnType
+];
+
 /**
  * Check if the provided diagnostic should be ignored.
  *
@@ -82,7 +87,7 @@ const ignoreDiagnostic = (diagnostic: TSDiagnostic, expectedErrors: Map<Position
 		return true;
 	}
 
-	if (diagnostic.code !== DiagnosticCode.ArgumentTypeIsNotAssignableToParameterType) {
+	if (!diagnosticCodesToIgnore.includes(diagnostic.code)) {
 		return false;
 	}
 

--- a/source/lib/compiler.ts
+++ b/source/lib/compiler.ts
@@ -71,7 +71,8 @@ const extractExpectErrorRanges = (sourceFile: SourceFile) => {
 
 const diagnosticCodesToIgnore = [
 	DiagnosticCode.ArgumentTypeIsNotAssignableToParameterType,
-	DiagnosticCode.PropertyDoesNotExistOnType
+	DiagnosticCode.PropertyDoesNotExistOnType,
+	DiagnosticCode.CannotAssignToReadOnlyProperty
 ];
 
 /**

--- a/source/lib/interfaces.ts
+++ b/source/lib/interfaces.ts
@@ -8,7 +8,8 @@ export interface Context {
 export enum DiagnosticCode {
 	AwaitIsOnlyAllowedInAsyncFunction = 1308,
 	PropertyDoesNotExistOnType = 2339,
-	ArgumentTypeIsNotAssignableToParameterType = 2345
+	ArgumentTypeIsNotAssignableToParameterType = 2345,
+	CannotAssignToReadOnlyProperty = 2540
 }
 
 export interface Diagnostic {

--- a/source/lib/interfaces.ts
+++ b/source/lib/interfaces.ts
@@ -7,6 +7,7 @@ export interface Context {
 
 export enum DiagnosticCode {
 	AwaitIsOnlyAllowedInAsyncFunction = 1308,
+	PropertyDoesNotExistOnType = 2339,
 	ArgumentTypeIsNotAssignableToParameterType = 2345
 }
 

--- a/source/test/fixtures/expect-error/values/index.test-d.ts
+++ b/source/test/fixtures/expect-error/values/index.test-d.ts
@@ -2,3 +2,9 @@ import {expectError} from '../../../..';
 
 expectError<string>(1);
 expectError<string>('fo');
+
+const foo = {
+	bar: 'baz'
+};
+
+expectError(foo.quux);

--- a/source/test/fixtures/expect-error/values/index.test-d.ts
+++ b/source/test/fixtures/expect-error/values/index.test-d.ts
@@ -3,8 +3,9 @@ import {expectError} from '../../../..';
 expectError<string>(1);
 expectError<string>('fo');
 
-const foo = {
+const foo: {readonly bar: string} = {
 	bar: 'baz'
 };
 
+expectError(foo.bar = 'quux');
 expectError(foo.quux);


### PR DESCRIPTION
`ignoreError` should ignore more diagnostic errors:

- "property does not exist on type"
- "cannot assign to read-only property"

This PR adds the according diagnostic codes and filters them away when diagnostic is reported to be in an `expectError` statement.