### PR TITLE
Detect `expectError` statements in nested blocks

### DIFF
--- a/source/lib/compiler.ts
+++ b/source/lib/compiler.ts
@@ -1,7 +1,14 @@
 import * as path from 'path';
 import {
-	flattenDiagnosticMessageText, createProgram, SyntaxKind, Diagnostic as TSDiagnostic,
-	Program, SourceFile, Node, forEachChild} from 'typescript';
+	flattenDiagnosticMessageText,
+	createProgram,
+	SyntaxKind,
+	Diagnostic as TSDiagnostic,
+	Program,
+	SourceFile,
+	Node,
+	forEachChild
+} from 'typescript';
 import {Diagnostic, DiagnosticCode, Context, Location} from './interfaces';
 
 // List of diagnostic codes that should be ignored
@@ -23,10 +30,6 @@ const diagnosticCodesToIgnore = new Set<DiagnosticCode>([
 const extractExpectErrorRanges = (program: Program) => {
 	const expectedErrors = new Map<Location, Pick<Diagnostic, 'fileName' | 'line' | 'column'>>();
 
-	for (const sourceFile of program.getSourceFiles()) {
-		walkNodes(sourceFile);
-	}
-
 	function walkNodes(node: Node) {
 		if (node.kind === SyntaxKind.ExpressionStatement && node.getText().startsWith('expectError')) {
 			const location = {
@@ -35,7 +38,9 @@ const extractExpectErrorRanges = (program: Program) => {
 				end: node.getEnd()
 			};
 
-			const pos = node.getSourceFile().getLineAndCharacterOfPosition(node.getStart());
+			const pos = node
+				.getSourceFile()
+				.getLineAndCharacterOfPosition(node.getStart());
 
 			expectedErrors.set(location, {
 				fileName: location.fileName,
@@ -45,6 +50,10 @@ const extractExpectErrorRanges = (program: Program) => {
 		}
 
 		forEachChild(node, walkNodes);
+	}
+
+	for (const sourceFile of program.getSourceFiles()) {
+		walkNodes(sourceFile);
 	}
 
 	return expectedErrors;

--- a/source/lib/compiler.ts
+++ b/source/lib/compiler.ts
@@ -1,5 +1,7 @@
 import * as path from 'path';
-import {flattenDiagnosticMessageText, createProgram, SyntaxKind, Diagnostic as TSDiagnostic, Program, SourceFile} from 'typescript';
+import {
+	flattenDiagnosticMessageText, createProgram, SyntaxKind, Diagnostic as TSDiagnostic,
+	Program, SourceFile, Node, forEachChild} from 'typescript';
 import {Diagnostic, DiagnosticCode, Context, Location} from './interfaces';
 
 // List of diagnostic codes that should be ignored
@@ -22,18 +24,18 @@ const extractExpectErrorRanges = (program: Program) => {
 	const expectedErrors = new Map<Location, Pick<Diagnostic, 'fileName' | 'line' | 'column'>>();
 
 	for (const sourceFile of program.getSourceFiles()) {
-		for (const statement of sourceFile.statements) {
-			if (statement.kind !== SyntaxKind.ExpressionStatement || !statement.getText().startsWith('expectError')) {
-				continue;
-			}
+		walkNodes(sourceFile);
+	}
 
+	function walkNodes(node: Node) {
+		if (node.kind === SyntaxKind.ExpressionStatement && node.getText().startsWith('expectError')) {
 			const location = {
-				fileName: statement.getSourceFile().fileName,
-				start: statement.getStart(),
-				end: statement.getEnd()
+				fileName: node.getSourceFile().fileName,
+				start: node.getStart(),
+				end: node.getEnd()
 			};
 
-			const pos = statement.getSourceFile().getLineAndCharacterOfPosition(statement.getStart());
+			const pos = node.getSourceFile().getLineAndCharacterOfPosition(node.getStart());
 
 			expectedErrors.set(location, {
 				fileName: location.fileName,
@@ -41,6 +43,8 @@ const extractExpectErrorRanges = (program: Program) => {
 				column: pos.character
 			});
 		}
+
+		forEachChild(node, walkNodes);
 	}
 
 	return expectedErrors;

--- a/source/test/fixtures/expect-error/values/index.test-d.ts
+++ b/source/test/fixtures/expect-error/values/index.test-d.ts
@@ -9,3 +9,11 @@ const foo: {readonly bar: string} = {
 
 expectError(foo.bar = 'quux');
 expectError(foo.quux);
+
+// Ignore errors in deeply nested blocks, too
+try {
+	if (true) {
+		expectError(foo.bar = 'quux');
+		expectError(foo.quux);
+	}
+} catch (e) {}

--- a/source/test/fixtures/expect-error/values/index.test-d.ts
+++ b/source/test/fixtures/expect-error/values/index.test-d.ts
@@ -10,10 +10,10 @@ const foo: {readonly bar: string} = {
 expectError(foo.bar = 'quux');
 expectError(foo.quux);
 
-// Ignore errors in deeply nested blocks, too
+// Ignore errors in deeply nested blocks too
 try {
 	if (true) {
 		expectError(foo.bar = 'quux');
 		expectError(foo.quux);
 	}
-} catch (e) {}
+} catch {}


### PR DESCRIPTION
Currently, `expectError` detection only checks statements in the outermost layer of a file. This misses all `expectError` statements that are nested inside of blocks (like `if` or `try`) producing false positives during linting.

This PR extends this detection mechanism to walk through the whole syntax tree to find `expectError` statements.